### PR TITLE
fix: clickable social link

### DIFF
--- a/components/MainPage/MainPageGetInvolvedItem.vue
+++ b/components/MainPage/MainPageGetInvolvedItem.vue
@@ -13,9 +13,15 @@ const { buttonText = "Join" } = defineProps<{
 
 <template>
   <div class="get-involved-item">
-    <img :src="image" alt="" class="get-involved-item-image">
-    <SectionTitle class="get-involved-item-title" small>{{ title }}</SectionTitle>
-    <SectionDescription class="get-involved-item-description">{{ description }}</SectionDescription>
+    <a :href="link">
+      <img :src="image" alt="" class="get-involved-item-image" />
+    </a>
+    <SectionTitle class="get-involved-item-title" small>
+      {{ title }}
+    </SectionTitle>
+    <SectionDescription class="get-involved-item-description">
+      {{ description }}
+    </SectionDescription>
     <LinkButton :href="link" :type="buttonType">
       {{ buttonText }}
       <Icon name="arrow" />


### PR DESCRIPTION
It looks like removing ssr hydration require further experiment.

As the oldest blog page date data mismatching happens during cloudflare check preview, but not during `npm run dev`.

Maybe the data needs to be modified from parent component/page.

So just fix clickable social link for now