### PR TITLE
fix: firefox fix's bug is fixed

### DIFF
--- a/components/NewsArticlePage/NewsArticlePageSplash.vue
+++ b/components/NewsArticlePage/NewsArticlePageSplash.vue
@@ -114,6 +114,7 @@ onMounted(() => {
   position: absolute;
   right: 0;
   width: 100%;
+  max-width: 711px;
   border-radius: 20px;
   aspect-ratio: 16 / 9;
 


### PR DESCRIPTION
## Issue number
#145 

## Description
Found #145  fix is causing news image to take up whole space. And this will fix.