### PR TITLE
148 create a license page and centralised copyright file for third party assets

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -46,6 +46,7 @@ const links = useLinks();
 
           <NuxtLink v-if="!featureFlags.minimal" class="footer-link" href="#">Assets</NuxtLink>
           <NuxtLink :href="links.pressKit" aria-label="press kit" class="footer-link">Press Kit</NuxtLink>
+          <NuxtLink aria-label="license" class="footer-link" href="/license">License</NuxtLink>
         </div>
       </div>
 

--- a/components/LicensePage/LicensePageContent.vue
+++ b/components/LicensePage/LicensePageContent.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { MarkdownRoot } from "@nuxt/content";
+
+const { body } = defineProps<{
+  body: MarkdownRoot;
+}>();
+</script>
+
+<template>
+  <ContentRendererMarkdown
+    :value="body"
+    class="content-renderer"
+  />
+</template>
+
+<style scoped lang="scss">
+.content-renderer {
+  color: #fff;
+  font-size: 16px;
+  width: 100%;
+  margin: 40px auto;
+
+  :deep(h1) {
+    font-size: 32px;
+    font-weight: 800;
+    margin: 20px 0;
+  }
+
+  :deep(h2) {
+    font-size: 25px;
+    font-weight: 800;
+    margin: 20px 0;
+  }
+
+  :deep(h3) {
+    font-size: 20px;
+    font-weight: 800;
+    margin: 20px 0;
+  }
+
+  :deep(h4) {
+    font-size: 17px;
+    font-weight: 800;
+    margin: 20px 0;
+  }
+
+  :deep(h5) {
+    font-size: 15px;
+    font-weight: 800;
+    margin: 20px 0;
+  }
+
+  :deep(p) {
+    margin-bottom: 20px;
+  }
+
+  :deep(a) {
+    color: #3388ff;
+    font-weight: bold;
+  }
+
+  :deep(h2 a) {
+    color: white;
+    font-weight: bold;
+  }
+
+  :deep(h3 a) {
+    color: white;
+    font-weight: bold;
+  }
+
+  :deep(ul) {
+    margin-left: 1.5rem;
+    list-style-type: circle;
+  }
+
+  :deep(li) {
+    margin-bottom: 1rem;
+  }
+}
+</style>

--- a/components/NewsArticlePage/NewsArticlePageSplash.vue
+++ b/components/NewsArticlePage/NewsArticlePageSplash.vue
@@ -19,7 +19,7 @@ onMounted(() => {
 
 <template>
   <div class="news-article-page-splash">
-    <img :src="image" alt="" class="banner" />
+    <img :src="image" alt="" class="banner">
 
     <div class="info">
       <div class="row">
@@ -31,7 +31,7 @@ onMounted(() => {
       </h1>
 
       <div class="row">
-        <img :src="authorImage" alt="" class="avatar" />
+        <img :alt="`${author} avatar`" :src="authorImage" class="avatar">
         <div class="username">{{ author }}</div>
         <div class="date">{{ dateString }}</div>
       </div>

--- a/content/license/license.md
+++ b/content/license/license.md
@@ -1,0 +1,53 @@
+---
+title: Redot Engine License
+description: License of Redot Engine
+type: "license"
+---
+
+## The Engine
+
+### Redot Engine License Agreement
+Redot Engine is a [free and open source software](https://en.wikipedia.org/wiki/Free_and_open_source_software) released under the permissive [MIT license](https://github.com/Redot-Engine/redot-engine/blob/master/LICENSE.txt) (also known as the Expat license).
+
+This license grants users the following freedoms:
+
+- You are free to use Redot Engine, for any purpose.
+- You can study how Redot Engine works and change it.
+- You can distribute unmodified and changed versions of Redot Engine, even commercially and under a different license (including proprietary).
+
+### Attribution Notice
+
+Redot Engine is derived from Godot Engine, which is free and open source software also licensed under the [MIT license](https://github.com/godotengine/godot/blob/master/LICENSE.txt).
+
+As required by the MIT license, whenever you distribute Redot Engine or derivative works based on it, you must include both the Redot Engine and 
+Godot Engine copyright notices and license statements.
+
+## Your game
+
+Redot Engine's license terms and copyright do not apply to the content you create with it; you are free to license your games how you see best fit,
+and will be their sole copyright owner(s).
+
+Note however that the Redot Engine binary that you would distribute with your game is a copy of the "Software" as defined in the license, and you are therefore required to include 
+the copyright notice and license statement somewhere in your documentation.
+
+The Redot Engine developers consider that a link to this page ([redotengine.org/license](/license)) in your game documentation or credits would be an acceptable way to satisfy the license terms.
+
+See [Complying with Licenses](https://docs-latest.redotengine.org/about/complying_with_licenses) in the documentation for more information.
+
+## License text
+
+A plain text version of the license is available from the following repositories:
+
+- For Godot Engine: [LICENSE.txt](https://github.com/godotengine/godot/blob/master/LICENSE.txt)
+- For Redot Engine: [LICENSE.txt](https://github.com/Redot-Engine/redot-engine/blob/master/LICENSE.txt)
+
+## Third-party components
+
+Redot Engine uses several third-party libraries and code snippets, which are distributed under their own license and copyright statements. 
+All such components are compatible with the terms of Redot Engine's MIT license. You can refer to [this list](https://github.com/Redot-Engine/redot-engine/blob/master/COPYRIGHT.txt) for a comprehensive overview 
+of all third-party components used in Redot Engine and their respective licenses.
+
+## Disclaimer
+The above explanations of Redot Engine's license terms and their implications for its users do not constitute legal advice. 
+They reflect the Redot Engine team's understanding of their own license terms and that of their third-party components; 
+in case of doubt, please refer to your lawyer.

--- a/pages/license/index.vue
+++ b/pages/license/index.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <Header always-opaque />
+  <MaxWidthContainer class="license-page-container">
+    <div class="header">
+      <h1 class="section-title-text">License</h1>
+    </div>
+  </MaxWidthContainer>
+  <Footer />
+</template>
+
+<style scoped lang="scss">
+@use "@/assets/styles/mixins";
+
+.license-page-container {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding-top: 40px;
+  padding-bottom: 40px;
+  margin-top: 56px;
+}
+
+.header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.section-title-text {
+  display: inline-block;
+  font-size: 36px;
+  font-weight: 800;
+  position: relative;
+
+  &::before {
+    content: "";
+    position: absolute;
+    bottom: 4px;
+    left: 0;
+    right: 0;
+    height: 10px;
+    background-color: #fe3f02;
+    z-index: -1;
+  }
+
+  @include mixins.mobile-and-smaller {
+    font-size: 24px;
+
+    &::before {
+      height: 6px;
+    }
+  }
+}
+</style>

--- a/pages/license/index.vue
+++ b/pages/license/index.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
+const { data } = await useAsyncData("license", () => (
+    queryContent("/license").where({ type: { $eq: "license" } }).findOne()
+));
 
+useHead(data.value?.title ? {
+  title: data.value?.title,
+}: {});
 </script>
 
 <template>
@@ -8,6 +14,7 @@
     <div class="header">
       <h1 class="section-title-text">License</h1>
     </div>
+    <LicensePageContent :body="data?.body!" />
   </MaxWidthContainer>
   <Footer />
 </template>


### PR DESCRIPTION
## Issue number
- #148 
- #138 

## Description
- Created license page route and content (markdown)
- Linked to Redot Engine's copyright and license text statements
- Added link to license in the Footer

*IMPORTANT: DO NOT MERGE THIS PR UNTIL THERE IS EXPLICIT PR APPROVAL FROM DREW / ANDEVRS*