### PR TITLE
feat: added download links from Github

### DIFF
--- a/components/DownloadPage/DownloadPageHero.vue
+++ b/components/DownloadPage/DownloadPageHero.vue
@@ -18,7 +18,7 @@
           <Icon :name="platformIcons[platform] ?? 'windows'" />
         </LinkButton>
         <LinkButton :href="links.releasePage" type="ghost">
-          Other versions
+          More download options
           <Icon name="arrow" />
         </LinkButton>
       </div>

--- a/components/DownloadPage/DownloadPageThreeSteps.vue
+++ b/components/DownloadPage/DownloadPageThreeSteps.vue
@@ -20,6 +20,7 @@ const links = useLinks();
         <DownloadPageThreeStepsItem
           :links="[
             { text: 'Download for Windows', url: getPlatformDownloadLink('windows') },
+            { text: 'Download for Mac', url: getPlatformDownloadLink('mac') },
             { text: 'Download for Linux', url: getPlatformDownloadLink('linux') },
             { text: 'Download for Android', url: getPlatformDownloadLink('android') },
           ]"

--- a/lib/platformDownloadLink.ts
+++ b/lib/platformDownloadLink.ts
@@ -1,9 +1,9 @@
 export const getPlatformDownloadLink = (platform: string): string => {
   const downloadLinks: { [key: string]: string } = {
-    windows: "https://download.redotengine.org/release/4.3/Redot_v4.3-beta.1_win64.exe.zip",
-    linux: "https://download.redotengine.org/release/4.3/Redot_v4.3-beta.1_linux.x86_64.zip",
+    windows: "https://github.com/Redot-Engine/redot-engine/releases/download/redot-4.3-beta.2/Redot_v4.3-beta.2_win64.exe.zip",
+    linux: "https://github.com/Redot-Engine/redot-engine/releases/download/redot-4.3-beta.2/Redot_v4.3-beta.2_linux.x86_64.zip",
     android: "https://download.redotengine.org/release/4.4/android-editor.zip",
-    mac: "https://download.redotengine.org/release/4.3/Redot_v4.3-beta.1_macos.zip",
+    mac: "https://github.com/Redot-Engine/redot-engine/releases/download/redot-4.3-beta.2/Redot_v4.3-beta.2_macos.universal.zip",
   };
 
   return (


### PR DESCRIPTION
## Issue number
#172 

## Description
- Point directly to Github so that we do not have to rely on the R2 bucket in Cloudflare
- Updated text to be "More download options" incase users want a different type of download (e.g. 32 bit)
- Added MacOS option in the 3 steps